### PR TITLE
価格計算ロジックの変更: 枚数・本数選択時の価格未定表示対応

### DIFF
--- a/src/components/features/CartItem.tsx
+++ b/src/components/features/CartItem.tsx
@@ -14,6 +14,7 @@ interface CartItemData {
   remarks?: string
   quantityMethod: 'WEIGHT' | 'PIECE' | 'PACK' | 'PIECE_COUNT'
   priceType: 'WEIGHT_BASED' | 'PACK'
+  isPriceUndetermined?: boolean
   pieceDetails?: {
     pieceGrams?: number
     pieceCount?: number
@@ -115,11 +116,11 @@ export function CartItem({ item, onRemoveItem }: CartItemProps) {
         <div className="text-right">
           <div className="text-sm text-gray-600">
             <span>
-              合計: {formatPrice(item.subtotal)}
+              合計: {item.isPriceUndetermined ? '価格未定' : formatPrice(item.subtotal)}
             </span>
           </div>
           <div className="text-lg font-bold text-red-600">
-            {formatPrice(item.subtotal)}
+            {item.isPriceUndetermined ? '価格未定' : formatPrice(item.subtotal)}
           </div>
         </div>
       </div>

--- a/src/components/features/OrderSummary.tsx
+++ b/src/components/features/OrderSummary.tsx
@@ -5,12 +5,18 @@ interface OrderSummaryProps {
     price: number
     priceType: 'WEIGHT_BASED' | 'PACK'
     subtotal?: number
+    isPriceUndetermined?: boolean
   }>
   className?: string
 }
 
 export function OrderSummary({ items, className }: OrderSummaryProps) {
-  const calculateItemTotal = (item: { quantity: number; price: number; priceType: 'WEIGHT_BASED' | 'PACK'; subtotal?: number }) => {
+  const calculateItemTotal = (item: { quantity: number; price: number; priceType: 'WEIGHT_BASED' | 'PACK'; subtotal?: number; isPriceUndetermined?: boolean }) => {
+    // 価格未定の場合は0を返す
+    if (item.isPriceUndetermined) {
+      return 0
+    }
+    
     // subtotalが提供されている場合はそれを使用、そうでなければ従来の計算
     if (item.subtotal !== undefined) {
       return item.subtotal
@@ -23,6 +29,7 @@ export function OrderSummary({ items, className }: OrderSummaryProps) {
     }
   }
 
+  const hasUndeterminedPrice = items.some(item => item.isPriceUndetermined)
   const totalAmount = items.reduce((sum, item) => sum + calculateItemTotal(item), 0)
 
   const formatPrice = (price: number) => {
@@ -44,14 +51,16 @@ export function OrderSummary({ items, className }: OrderSummaryProps) {
         
         <div className="flex justify-between">
           <span>小計:</span>
-          <span>{formatPrice(totalAmount)}</span>
+          <span>{hasUndeterminedPrice ? '価格未定商品を含む' : formatPrice(totalAmount)}</span>
         </div>
         
         <hr className="my-3" />
         
         <div className="flex justify-between items-center text-lg font-bold">
           <span>合計:</span>
-          <span className="text-red-600">{formatPrice(totalAmount)}</span>
+          <span className="text-red-600">
+            {hasUndeterminedPrice ? '価格未定商品を含む' : formatPrice(totalAmount)}
+          </span>
         </div>
       </div>
       

--- a/src/components/features/ProductDetailClient.tsx
+++ b/src/components/features/ProductDetailClient.tsx
@@ -40,6 +40,7 @@ export function ProductDetailClient({ product }: ProductDetailClientProps) {
   const [quantity, setQuantity] = useState(1)
   const [subtotal, setSubtotal] = useState(0)
   const [selectedMethod, setSelectedMethod] = useState('')
+  const [isPriceUndetermined, setIsPriceUndetermined] = useState(false)
   const [selectedOptions, setSelectedOptions] = useState<{
     selectedUsage?: string
     selectedFlavor?: string
@@ -73,22 +74,31 @@ export function ProductDetailClient({ product }: ProductDetailClientProps) {
         productId: product.id,
         quantity,
         price: product.basePrice,
-        subtotal,
+        subtotal: isPriceUndetermined ? 0 : subtotal,
         selectedMethod,
         selectedUsage: selectedOptions.selectedUsage,
         selectedFlavor: selectedOptions.selectedFlavor,
         remarks: remarks,
         pieceDetails: pieceDetails,
+        isPriceUndetermined,
       }
 
       // セッションストレージにカート情報を保存
       const existingCart = JSON.parse(sessionStorage.getItem('cart') || '[]')
-      const existingItemIndex = existingCart.findIndex((item: any) => 
+      const existingItemIndex = existingCart.findIndex((item: {
+        productId: string;
+        selectedMethod: string;
+        selectedUsage?: string;
+        selectedFlavor?: string;
+        remarks?: string;
+        isPriceUndetermined?: boolean;
+      }) => 
         item.productId === cartItem.productId &&
         item.selectedMethod === cartItem.selectedMethod &&
         item.selectedUsage === cartItem.selectedUsage &&
         item.selectedFlavor === cartItem.selectedFlavor &&
-        item.remarks === cartItem.remarks
+        item.remarks === cartItem.remarks &&
+        item.isPriceUndetermined === cartItem.isPriceUndetermined
       )
 
       if (existingItemIndex >= 0) {
@@ -133,15 +143,15 @@ export function ProductDetailClient({ product }: ProductDetailClientProps) {
           />
 
           <QuantitySelector
-            priceType={product.priceType}
             quantityMethods={product.quantityMethods}
             basePrice={product.basePrice}
             unit={product.unit}
             hasStock={product.hasStock}
-            onQuantityChange={(qty, sub, method, details) => {
+            onQuantityChange={(qty, sub, method, details, priceUndetermined) => {
               setQuantity(qty)
               setSubtotal(sub)
               setSelectedMethod(method)
+              setIsPriceUndetermined(priceUndetermined || false)
               if (details) {
                 setPieceDetails(details)
               }
@@ -207,7 +217,9 @@ export function ProductDetailClient({ product }: ProductDetailClientProps) {
 
           <div className="flex justify-between items-center text-lg font-bold">
             <span>合計:</span>
-            <span className="text-red-600">{formatPrice(subtotal)}</span>
+            <span className="text-red-600">
+              {isPriceUndetermined ? '価格未定' : formatPrice(subtotal)}
+            </span>
           </div>
 
           <Button


### PR DESCRIPTION
## 概要
Issue #11 で要求されている価格計算ロジックの変更を実装しました。数量選択方法によって「価格未定」を表示するようになります。

## 変更内容
- [x] バグ修正
- [ ] 新機能の追加
- [ ] リファクタリング
- [ ] ドキュメントの更新
- [ ] テストの追加・修正
- [ ] その他（詳細を記載）

## 実装の詳細
### 追加・変更されたファイル
- `src/components/features/QuantitySelector.tsx` - 価格未定判定ロジックとコールバック拡張
- `src/components/features/ProductDetailClient.tsx` - 価格未定状態の管理と表示
- `src/components/features/CartItem.tsx` - カートアイテムの価格未定表示
- `src/components/features/OrderSummary.tsx` - 注文合計での価格未定商品を含む表示

### 主な変更点
- 枚数選択（PIECE）の場合は常に「価格未定」を表示
- 本数選択（PIECE_COUNT）の場合、単位が「本」でない商品（100g単価商品など）は「価格未定」を表示
- 本数選択で単位が「本」の商品（豚バラ串など）は従来通り価格計算
- カート機能でも価格未定商品に対応
- 注文合計画面で価格未定商品が含まれる場合の表示対応

## テスト
- [x] 既存のテストがすべて通過することを確認した
- [ ] 新しいテストを追加した（該当する場合）
- [x] 手動でテストを行い、期待通りに動作することを確認した

### テストケース
- 枚数選択時に「価格未定」が表示されることを確認
- 本数選択（100g単価商品）で「価格未定」が表示されることを確認
- 本数選択（本単価商品）で価格が計算されることを確認
- カートに価格未定商品が追加されることを確認
- 注文合計で「価格未定商品を含む」が表示されることを確認

## 確認事項
- [x] コードレビューの準備ができている
- [ ] 関連するドキュメントを更新した
- [ ] データベースの変更がある場合、マイグレーションファイルが含まれている
- [ ] 環境変数の変更がある場合、READMEやドキュメントを更新した

## スクリーンショット（UI変更がある場合）
| Before | After |
|--------|-------|
| 価格が常に計算される | 条件に応じて「価格未定」表示 |

## 関連Issue・PR
- Closes #11

## 追加情報
- 既存の価格計算ロジックはそのまま保持されており、後方互換性を維持しています
- 新しいisPriceUndetermined フラグによって価格未定商品を適切に管理しています
- ビルド・リント確認済みで、既存の機能に影響を与えません

🤖 Generated with [Claude Code](https://claude.ai/code)